### PR TITLE
Use RTLD_GLOBAL for the python-library

### DIFF
--- a/python.pri
+++ b/python.pri
@@ -3,6 +3,9 @@ PYTHON_CONFIG = python3.3-config
 QMAKE_LIBS += $$system($$PYTHON_CONFIG --ldflags)
 QMAKE_CXXFLAGS += $$system($$PYTHON_CONFIG --includes)
 
+# Determinate the python library we link against and set
+# a define for it. Its the last entry in the via --libs
+# returned list of libraries.
 PYTHON_LIBRARIES = $$system($$PYTHON_CONFIG --libs)
 PYTHON_LIBRARY = ""
 for(lib, PYTHON_LIBRARIES) {

--- a/src/pyotherside_plugin.cpp
+++ b/src/pyotherside_plugin.cpp
@@ -45,12 +45,18 @@ PyOtherSideExtensionPlugin::initializeEngine(QQmlEngine *engine, const char *uri
     Q_ASSERT(QString(PYOTHERSIDE_PLUGIN_ID) == uri);
 
 #if defined(Q_OS_UNIX)
+    // Its needed to dlopen the python library using RTLD_GLOBAL so modules
+    // dynamic loaded later, which not link against the python library, find
+    // its symbols. This is only needed on Unix where our/python symbols may
+    // be hidden and not acccessible to libraries/modules we/python loads. By
+    // loading the python library here again using RTLD_GLOBAL we make its
+    // symbols proper accessible to other libraries/modules.
     QByteArray pythonlib(PYTHON_LIBRARY);
     if (!pythonlib.isEmpty()) {
         QLibrary lib(pythonlib);
         lib.setLoadHints(QLibrary::ExportExternalSymbolsHint | QLibrary::ResolveAllSymbolsHint);
         if (!lib.load())
-            qWarning() << "RTLD_GLOBAL" << pythonlib << lib.errorString();
+            qWarning() << "Failed loading python library" << pythonlib << lib.errorString();
     }
 #endif
 


### PR DESCRIPTION
Needed cause the QQmlExtensionPlugin is loaded
using RTLD_LOCAL and since python dynamic
loads additional libraries that may need to
access libpython API while they not load
the library themself its needed to make
sure libpython is loaded using RTLD_GLOBAL.

See http://forum.teamspeak.com/showthread.php/91916-RTLD_GLOBAL-in-dlopen-of-plugins-on-unix
for more background details.

This fixes the bug reported at
https://lists.launchpad.net/ubuntu-phone/msg04709.html
as was confirmed by the reporter via Twitter.

NOTE:
There is one case no optimal in this patch: Currently the python library is determinated in the pri-file and passed as defined but that define is relative means only the library-name and doesn't have the full path. The proper path is later on determinated with QLibrary.
Potential problem with that approach is that if there are two python libraries with the same name but in different paths I am not 100% sure that the proper library is picked :-/
I think an ideal patch would find a way to fetch the full qualified python libname including the path. I am not sure how to do that. Since when we load the library we already have a full python API available it would be possible to bypass the pri-change fully and use the Python C-API direct I think. So, maybe there is a proper Python C-API (pr python itself) call/code to fetch the full qualified python libname?
