### PR TITLE
Qt 5.4 new objects/arrays API support

### DIFF
--- a/src/qvariant_converter.h
+++ b/src/qvariant_converter.h
@@ -26,6 +26,7 @@
 #include <QDate>
 #include <QDateTime>
 #include <QDebug>
+#include <QJSValue>
 
 class QVariantListBuilder : public ListBuilder<QVariant> {
     public:
@@ -107,6 +108,14 @@ class QVariantDictIterator : public DictIterator<QVariant> {
 
 
 class QVariantConverter : public Converter<QVariant> {
+     private:
+        QVariant stripQJSValue(QVariant &v) {
+            if (v.userType() == qMetaTypeId<QJSValue>()) {
+                return v.value<QJSValue>().toVariant();
+            } else {
+                return v;
+            }
+        }
     public:
         QVariantConverter() : stringstorage() {}
         virtual ~QVariantConverter() {}
@@ -116,7 +125,7 @@ class QVariantConverter : public Converter<QVariant> {
                 return QOBJECT;
             }
 
-            QMetaType::Type t = (QMetaType::Type)v.type();
+            QMetaType::Type t = (QMetaType::Type)stripQJSValue(v).type();
             switch (t) {
                 case QMetaType::Bool:
                     return BOOLEAN;
@@ -153,11 +162,13 @@ class QVariantConverter : public Converter<QVariant> {
             }
         }
 
-        virtual ListIterator<QVariant> *list(QVariant &v) {
+        virtual ListIterator<QVariant> *list(QVariant &v_) {
+            QVariant v = stripQJSValue(v_);
             return new QVariantListIterator(v);
         }
 
-        virtual DictIterator<QVariant> *dict(QVariant &v) {
+        virtual DictIterator<QVariant> *dict(QVariant &v_) {
+            QVariant v = stripQJSValue(v_);
             return new QVariantDictIterator(v);
         }
 


### PR DESCRIPTION
As per https://qt.gitorious.org/qt/qtdeclarative/commit/3dbe05f6bf3fd51ce8097c35f6c7f12b39acb0f6 the API for JS arrays has changed and now instead of QVariant containing a list, a QVariant containing QJSValue is returned, which needs to be converted to a variant.

We've detected the bug when testing our application after migrating to 5.4 and we were getting `Cannot convert: QVariant(QJSValue, )` errors followed by `Not a parameter list in call to (...)`.

After applying this patch errors are gone and our application works correctly. It should be compatible with older Qt versions too, because it only changes the behaviour when `v.userType() == qMetaTypeId<QJSValue>` which wasn't handled before.
