### PR TITLE
Fixed compile errors after last Qt 5.4 patch

### DIFF
--- a/src/converter.h
+++ b/src/converter.h
@@ -109,7 +109,7 @@ class Converter {
             QOBJECT,
         };
 
-        virtual enum Type type(V&) = 0;
+        virtual enum Type type(const V&) = 0;
         virtual long long integer(V&) = 0;
         virtual double floating(V&) = 0;
         virtual bool boolean(V&) = 0;

--- a/src/pyobject_converter.h
+++ b/src/pyobject_converter.h
@@ -139,7 +139,7 @@ class PyObjectConverter : public Converter<PyObject *> {
             }
         }
 
-        virtual enum Type type(PyObject *&o) {
+        virtual enum Type type(PyObject * const & o) {
             if (PyObject_TypeCheck(o, &pyotherside_QObjectType)) {
                 return QOBJECT;
             } else if (PyObject_TypeCheck(o, &pyotherside_QObjectMethodType)) {

--- a/src/qvariant_converter.h
+++ b/src/qvariant_converter.h
@@ -66,7 +66,7 @@ class QVariantDictBuilder : public DictBuilder<QVariant> {
 
 class QVariantListIterator : public ListIterator<QVariant> {
     public:
-        QVariantListIterator(QVariant &v) : list(v.toList()), pos(0) {}
+        QVariantListIterator(const QVariant &v) : list(v.toList()), pos(0) {}
         virtual ~QVariantListIterator() {}
 
         virtual bool next(QVariant *v) {
@@ -87,7 +87,7 @@ class QVariantListIterator : public ListIterator<QVariant> {
 
 class QVariantDictIterator : public DictIterator<QVariant> {
     public:
-        QVariantDictIterator(QVariant &v) : dict(v.toMap()), keys(dict.keys()), pos(0) {}
+        QVariantDictIterator(const QVariant &v) : dict(v.toMap()), keys(dict.keys()), pos(0) {}
         virtual ~QVariantDictIterator() {}
 
         virtual bool next(QVariant *key, QVariant *value) {
@@ -114,7 +114,7 @@ class QVariantConverter : public Converter<QVariant> {
         QVariantConverter() : stringstorage() {}
         virtual ~QVariantConverter() {}
 
-        virtual enum Type type(QVariant &v) {
+        virtual enum Type type(const QVariant &v) {
             if (v.canConvert<QObject *>()) {
                 return QOBJECT;
             }
@@ -170,7 +170,7 @@ class QVariantConverter : public Converter<QVariant> {
         virtual DictIterator<QVariant> *dict(QVariant &v) {
             // XXX: Until we support boxing QJSValue objects directly in Python
             if (v.userType() == qMetaTypeId<QJSValue>()) {
-                return new QVariantListIterator(v.value<QJSValue>().toVariant());
+                return new QVariantDictIterator(v.value<QJSValue>().toVariant());
             }
             return new QVariantDictIterator(v);
         }


### PR DESCRIPTION
This changes argument references in  `Converter::type`, `QVariantListIterator` and `QVariantDictIterator` to `const` to allow using `QVariant::value<QJSValue>()` return values directly.

Also changes `QVariantConverter::dict` return value to return `QVariantDictIterator` correctly.
