### PR TITLE
Unbox QJSValue from QVariant in the GUI thread to prevent race condition...

### DIFF
--- a/src/qvariant_converter.h
+++ b/src/qvariant_converter.h
@@ -22,6 +22,7 @@
 #include "converter.h"
 
 #include <QVariant>
+#include <QCoreApplication>
 
 #include <QTime>
 #include <QDate>
@@ -29,6 +30,7 @@
 #include <QJSValue>
 
 #include <QDebug>
+#include <QThread>
 
 class QVariantListBuilder : public ListBuilder<QVariant> {
     public:
@@ -150,8 +152,8 @@ class QVariantConverter : public Converter<QVariant> {
                     if (userType == qMetaTypeId<PyObjectRef>()) {
                         return PYOBJECT;
                     } else if (userType == qMetaTypeId<QJSValue>()) {
-                        // TODO: Support boxing a QJSValue as reference in Python
-                        return type(v.value<QJSValue>().toVariant());
+                        Q_ASSERT(QThread::currentThread() == qApp->thread());
+                        return type(QVariant());
                     } else {
                         qDebug() << "Cannot convert:" << v;
                         return NONE;


### PR DESCRIPTION
... in QML engine

Calling QJSValue::toVariant() can cause QJSValue to call into QML engine. Since
we perform this correction from QPythonWriter thread context, we end up calling
QML engine from non-GUI thread and causing race conditions and crashes.

This change performs the initial unboxing in QPython::call() and passes to
QPythonWriter the actual value of QJSValue in QVariant.

This fixes issue #36.