### PR TITLE
Import names from module

### DIFF
--- a/src/qpython.h
+++ b/src/qpython.h
@@ -131,6 +131,65 @@ class QPython : public QObject {
         evaluate(QString expr);
 
         /**
+         * \brief Asynchronously import objects from Python module
+         *
+         * Imports objects, given by list of names, from Python module asynchronously.
+         * The function will return immediately. If the module is successfully imported,
+         * the supplied \a callback will be called. Only then will the
+         * imported module be available:
+         *
+         * \code
+         * Python {
+         *     Component.onCompleted: {
+         *         importNames('os', ['path'], function (success) {
+         *             if (success) {
+         *                 // You can use the "path" submodule here
+         *             } else {
+         *                 console.log('Importing failed')
+         *             }
+         *         });
+         *     }
+         * }
+         * \endcode
+         *
+         * If an error occurs while trying to import, the signal error()
+         * will be emitted with detailed information about the error.
+         *
+         * \arg name The name of the Python module to import from
+         * \arg args The name of Python objects to import from the module
+         * \arg callback The JS callback to be called when the module is
+         *               successfully imported
+         **/
+        Q_INVOKABLE void
+        importNames(QString name, QVariant args, QJSValue callback);
+
+        /**
+         * \brief Synchronously import objects from Python module
+         *
+         * Imports objects, given by list of names, from Python module synchronously.
+         * This function will block until the objects are imported and available.
+         * In general, you should use importNames() instead of this function
+         * to avoid blocking the QML UI thread. Example use:
+         *
+         * \code
+         * Python {
+         *     Component.onCompleted: {
+         *         var success = importNames_sync('os', ['path']);
+         *         if (success) {
+         *             // You can use the "path" submodule here
+         *         }
+         *     }
+         * }
+         * \endcode
+         *
+         * \arg name The name of the Python module to import from
+         * \arg args The name of Python objects to import from the module
+         * \result \c true if the import was successful, \c false otherwise
+         **/
+        Q_INVOKABLE bool
+        importNames_sync(QString name, QVariant args);
+
+        /**
          * \brief Asynchronously import a Python module
          *
          * Imports a Python module by name asynchronously. The function
@@ -304,6 +363,7 @@ class QPython : public QObject {
         /* For internal use only */
         void process(QVariant func, QVariant args, QJSValue *callback);
         void import(QString name, QJSValue *callback);
+        void import_names(QString name, QVariant args, QJSValue *callback);
 
     private slots:
         void receive(QVariant data);

--- a/src/qpython_worker.cpp
+++ b/src/qpython_worker.cpp
@@ -48,3 +48,12 @@ QPythonWorker::import(QString name, QJSValue *callback)
         emit imported(result, callback);
     }
 }
+
+void
+QPythonWorker::import_names(QString name, QVariant args, QJSValue *callback)
+{
+    bool result = qpython->importNames_sync(name, args);
+    if (callback) {
+        emit imported(result, callback); // using the same imported signal at the end
+    }
+}

--- a/src/qpython_worker.h
+++ b/src/qpython_worker.h
@@ -36,6 +36,7 @@ class QPythonWorker : public QObject {
     public slots:
         void process(QVariant func, QVariant args, QJSValue *callback);
         void import(QString func, QJSValue *callback);
+        void import_names(QString func, QVariant args, QJSValue *callback);
 
     signals:
         void finished(QVariant result, QJSValue *callback);


### PR DESCRIPTION
The `importNames` and `importNames_sync` procedures import objects from the given module into current global space (`priv->globals`).

The definitions:

    void QPython::importNames(QString name, QVariant args, QJSValue callback)
    bool QPython::importNames_sync(QString module_name, QVariant args)

where `args` is the list with names of objects to import.

The procedures follow `importModule` code scheme.
`importNames_sync` starts with copy of `importModule_sync`,
but does not add the imported module to the `dict` `priv->globals`.
It creates a temporary dictionary filled with `priv->globals` and the module.
The objects are obtained by running `PyRun_String` on `'module_name.obj_name'` strings
in the loop over `obj_names` with the temp dictionary as global scope.
On success the object is inserted into `priv->globals`.

Following [the issue 53](https://github.com/thp/pyotherside/issues/53)