### PR TITLE
add license title

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,7 @@
 PyOtherSide: Asynchronous Python 3 Bindings for Qt 5
+
+ISC License
+
 Copyright (c) 2011, 2013, 2014, Thomas Perl <m@thp.io>
 
 Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
It's not strictly required, but it's useful metadata, and part of the recommended license template text:
- http://choosealicense.com/licenses/isc/
- https://opensource.org/licenses/isc-license
- http://spdx.org/licenses/ISC.html#licenseText