### PR TITLE
Fix call_sync when used with parameters

### DIFF
--- a/pyotherside.pro
+++ b/pyotherside.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS += src tests
+SUBDIRS += src tests qtquicktests
 
 tests.depends = src
 

--- a/qtquicktests/PythonRectangle.qml
+++ b/qtquicktests/PythonRectangle.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.3
+
+import io.thp.pyotherside 1.5
+
+Rectangle {
+    property bool ready: false;
+    property alias py: py;
+    Python {
+        id: py
+        Component.onCompleted: {
+            addImportPath(Qt.resolvedUrl('.'));
+            importModule('test_functions', function() {
+	        ready = true;
+            });
+        }
+    }
+}

--- a/qtquicktests/qtquicktests.cpp
+++ b/qtquicktests/qtquicktests.cpp
@@ -1,0 +1,2 @@
+#include <QtQuickTest/quicktest.h>
+QUICK_TEST_MAIN(qtquicktests)

--- a/qtquicktests/qtquicktests.pro
+++ b/qtquicktests/qtquicktests.pro
@@ -1,0 +1,4 @@
+TEMPLATE = app
+TARGET = qtquicktests
+CONFIG += warn_on qmltestcase
+SOURCES += qtquicktests.cpp

--- a/qtquicktests/run
+++ b/qtquicktests/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec ./qtquicktests -plugins ../src

--- a/qtquicktests/test_functions.py
+++ b/qtquicktests/test_functions.py
@@ -1,0 +1,4 @@
+def function_that_takes_one_parameter(parameter):
+    '''For tst_model_add_one:call_sync_with_parameters'''
+    assert parameter == 1
+    return 1

--- a/qtquicktests/tst_call_sync.qml
+++ b/qtquicktests/tst_call_sync.qml
@@ -1,0 +1,13 @@
+import QtTest 1.0
+
+PythonRectangle {
+    TestCase {
+        name: "call_sync_with_parameters"
+        when: ready
+
+        function test_call_sync_with_parameters() {
+            var result = py.call_sync('test_functions.function_that_takes_one_parameter', [1]);
+            compare(result, 1);
+        }
+    }
+}

--- a/src/qpython.h
+++ b/src/qpython.h
@@ -297,7 +297,11 @@ class QPython : public QObject {
          * \result The return value of the Python call as Qt data type
          **/
         Q_INVOKABLE QVariant
-        call_sync(QVariant func, QVariant args=QVariantList());
+        call_sync(QVariant func, QVariant boxed_args=QVariantList());
+
+        QVariant
+        call_internal(QVariant func, QVariant boxed_args=QVariantList(),
+            bool unbox=true);
 
         /**
          * \brief Get an attribute value of a Python object synchronously
@@ -361,7 +365,7 @@ class QPython : public QObject {
         void error(QString traceback);
 
         /* For internal use only */
-        void process(QVariant func, QVariant args, QJSValue *callback);
+        void process(QVariant func, QVariant unboxed_args, QJSValue *callback);
         void import(QString name, QJSValue *callback);
         void import_names(QString name, QVariant args, QJSValue *callback);
 
@@ -375,6 +379,8 @@ class QPython : public QObject {
         void disconnectNotify(const QMetaMethod &signal);
 
     private:
+        QVariantList unboxArgList(QVariant &args);
+
         static QPythonPriv *priv;
 
         QPythonWorker *worker;

--- a/src/qpython_worker.cpp
+++ b/src/qpython_worker.cpp
@@ -32,9 +32,9 @@ QPythonWorker::~QPythonWorker()
 }
 
 void
-QPythonWorker::process(QVariant func, QVariant args, QJSValue *callback)
+QPythonWorker::process(QVariant func, QVariant unboxed_args, QJSValue *callback)
 {
-    QVariant result = qpython->call_sync(func, args);
+    QVariant result = qpython->call_internal(func, unboxed_args, false);
     if (callback) {
         emit finished(result, callback);
     }

--- a/src/qpython_worker.h
+++ b/src/qpython_worker.h
@@ -34,7 +34,7 @@ class QPythonWorker : public QObject {
         ~QPythonWorker();
 
     public slots:
-        void process(QVariant func, QVariant args, QJSValue *callback);
+        void process(QVariant func, QVariant unboxed_args, QJSValue *callback);
         void import(QString func, QJSValue *callback);
         void import_names(QString func, QVariant args, QJSValue *callback);
 


### PR DESCRIPTION
One commit fixes the problem, and the second adds a test using qtquicktests. This involved adding a new test mechanism, so see what you think. With it, it's very easy to write tests in pure QML, which I think is helpful.