### PR TITLE
I am manually adding PyOtherSide to my project via a submodule.

### DIFF
--- a/src/qobject_ref.h
+++ b/src/qobject_ref.h
@@ -34,7 +34,7 @@ public:
     QObject *value() const { return qobject; }
     operator bool() const { return (qobject != 0); }
 
-private slots:
+private Q_SLOTS:
     void handleDestroyed(QObject *obj);
 
 private:

--- a/src/qpython.cpp
+++ b/src/qpython.cpp
@@ -135,7 +135,7 @@ QPython::importNames(QString name, QVariant args, QJSValue callback)
     if (!callback.isNull() && !callback.isUndefined() && callback.isCallable()) {
         cb = new QJSValue(callback);
     }
-    emit import_names(name, args, cb);
+    Q_EMIT import_names(name, args, cb);
 }
 
 bool
@@ -196,7 +196,7 @@ QPython::importModule(QString name, QJSValue callback)
     if (!callback.isNull() && !callback.isUndefined() && callback.isCallable()) {
         cb = new QJSValue(callback);
     }
-    emit import(name, cb);
+    Q_EMIT import(name, cb);
 }
 
 bool
@@ -270,7 +270,7 @@ QPython::receive(QVariant variant)
         }
     } else {
         // Default action
-        emit received(variant);
+        Q_EMIT received(variant);
     }
 }
 
@@ -324,7 +324,7 @@ QPython::call(QVariant func, QVariant boxed_args, QJSValue callback)
     // QML engine and we don't want that to happen from non-GUI thread
     QVariantList unboxed_args = unboxArgList(boxed_args);
 
-    emit process(func, unboxed_args, cb);
+    Q_EMIT process(func, unboxed_args, cb);
 }
 
 QVariant
@@ -479,7 +479,7 @@ void
 QPython::emitError(const QString &message)
 {
     if (error_connections) {
-        emit error(message);
+        Q_EMIT error(message);
     } else {
         // We should only print the error if SINCE_API_VERSION(1, 4), but as
         // the error messages are useful for debugging (especially if users

--- a/src/qpython.h
+++ b/src/qpython.h
@@ -341,7 +341,7 @@ class QPython : public QObject {
         Q_INVOKABLE QString
         pythonVersion();
 
-    signals:
+     Q_SIGNALS:
         /**
          * \brief Default event handler for \c pyotherside.send()
          *
@@ -369,7 +369,7 @@ class QPython : public QObject {
         void import(QString name, QJSValue *callback);
         void import_names(QString name, QVariant args, QJSValue *callback);
 
-    private slots:
+    private Q_SLOTS:
         void receive(QVariant data);
 
         void finished(QVariant result, QJSValue *callback);

--- a/src/qpython_priv.cpp
+++ b/src/qpython_priv.cpp
@@ -540,7 +540,7 @@ QPythonPriv::~QPythonPriv()
 void
 QPythonPriv::receiveObject(PyObject *o)
 {
-    emit receive(convertPyObjectToQVariant(o));
+    Q_EMIT receive(convertPyObjectToQVariant(o));
 }
 
 QString

--- a/src/qpython_priv.h
+++ b/src/qpython_priv.h
@@ -59,7 +59,7 @@ class QPythonPriv : public QObject {
         PyObjectRef pyotherside_mod;
         PyThreadState *thread_state;
 
-    signals:
+     Q_SIGNALS:
         void receive(QVariant data);
 };
 

--- a/src/qpython_worker.cpp
+++ b/src/qpython_worker.cpp
@@ -36,7 +36,7 @@ QPythonWorker::process(QVariant func, QVariant unboxed_args, QJSValue *callback)
 {
     QVariant result = qpython->call_internal(func, unboxed_args, false);
     if (callback) {
-        emit finished(result, callback);
+        Q_EMIT finished(result, callback);
     }
 }
 
@@ -45,7 +45,7 @@ QPythonWorker::import(QString name, QJSValue *callback)
 {
     bool result = qpython->importModule_sync(name);
     if (callback) {
-        emit imported(result, callback);
+        Q_EMIT imported(result, callback);
     }
 }
 
@@ -54,6 +54,6 @@ QPythonWorker::import_names(QString name, QVariant args, QJSValue *callback)
 {
     bool result = qpython->importNames_sync(name, args);
     if (callback) {
-        emit imported(result, callback); // using the same imported signal at the end
+        Q_EMIT imported(result, callback); // using the same imported signal at the end
     }
 }

--- a/src/qpython_worker.h
+++ b/src/qpython_worker.h
@@ -33,12 +33,12 @@ class QPythonWorker : public QObject {
         QPythonWorker(QPython *qpython);
         ~QPythonWorker();
 
-    public slots:
+    public Q_SLOTS:
         void process(QVariant func, QVariant unboxed_args, QJSValue *callback);
         void import(QString func, QJSValue *callback);
         void import_names(QString func, QVariant args, QJSValue *callback);
 
-    signals:
+    Q_SIGNALS:
         void finished(QVariant result, QJSValue *callback);
         void imported(bool result, QJSValue *callback);
 


### PR DESCRIPTION
This will help me debug issues that I may have with it.
However, since Python.h contains keywords that are specific to qt, we must instead use the macros.

Side note, how are you able to use Python.h and the qt keywords in the same project? Python.h contains structs/properties that are reserved qt keywords. I see you are using the keywords. How?