### PR TITLE
Include <dlfcn.h> (for RTLD_{GLOBAL,NOW})

### DIFF
--- a/src/global_libpython_loader.cpp
+++ b/src/global_libpython_loader.cpp
@@ -25,6 +25,7 @@ namespace GlobalLibPythonLoader {
 #define _GNU_SOURCE
 #include <link.h>
 
+#include <dlfcn.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
Building against musl libc otherwise fails here with
"global_libpython_loader.cpp:44:47: error: 'RTLD_GLOBAL' was not
declared in this scope".