### PR TITLE
Add support for QByteArray

### DIFF
--- a/src/converter.h
+++ b/src/converter.h
@@ -100,6 +100,7 @@ class Converter {
             FLOATING,
             BOOLEAN,
             STRING,
+            BYTES,
             LIST,
             DICT,
             DATE,
@@ -114,6 +115,7 @@ class Converter {
         virtual double floating(V&) = 0;
         virtual bool boolean(V&) = 0;
         virtual const char *string(V&) = 0;
+        virtual QByteArray bytes(V&) = 0;
         virtual ListIterator<V> *list(V&) = 0;
         virtual DictIterator<V> *dict(V&) = 0;
         virtual ConverterDate date(V&) = 0;
@@ -126,6 +128,7 @@ class Converter {
         virtual V fromFloating(double v) = 0;
         virtual V fromBoolean(bool v) = 0;
         virtual V fromString(const char *v) = 0;
+        virtual V fromBytes(const QByteArray &v) = 0;
         virtual V fromDate(ConverterDate date) = 0;
         virtual V fromTime(ConverterTime time) = 0;
         virtual V fromDateTime(ConverterDateTime dateTime) = 0;
@@ -154,6 +157,8 @@ convert(F from)
             return tconv.fromBoolean(fconv.boolean(from));
         case FC::STRING:
             return tconv.fromString(fconv.string(from));
+        case FC::BYTES:
+            return tconv.fromBytes(fconv.bytes(from));
         case FC::LIST:
             {
                 ListBuilder<T> *listBuilder = tconv.newList();

--- a/src/qvariant_converter.h
+++ b/src/qvariant_converter.h
@@ -134,6 +134,8 @@ class QVariantConverter : public Converter<QVariant> {
                     return FLOATING;
                 case QMetaType::QString:
                     return STRING;
+                case QMetaType::QByteArray:
+                    return BYTES;
                 case QMetaType::QDate:
                     return DATE;
                 case QMetaType::QTime:
@@ -213,6 +215,10 @@ class QVariantConverter : public Converter<QVariant> {
             return stringstorage.constData();
         }
 
+        virtual QByteArray bytes(QVariant &v) {
+            return stringstorage = v.toByteArray();
+        }
+
         virtual PyObjectRef pyObject(QVariant &v) {
             return v.value<PyObjectRef>();
         }
@@ -233,6 +239,7 @@ class QVariantConverter : public Converter<QVariant> {
         virtual QVariant fromFloating(double v) { return QVariant(v); }
         virtual QVariant fromBoolean(bool v) { return QVariant(v); }
         virtual QVariant fromString(const char *v) { return QVariant(QString::fromUtf8(v)); }
+        virtual QVariant fromBytes(const QByteArray &v) { return QVariant(v); }
         virtual QVariant fromDate(ConverterDate v) { return QVariant(QDate(v.y, v.m, v.d)); }
         virtual QVariant fromTime(ConverterTime v) { return QVariant(QTime(v.h, v.m, v.s, v.ms)); }
         virtual QVariant fromDateTime(ConverterDateTime v) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -62,6 +62,14 @@ test_converter_for(Converter<V> *conv)
     QVERIFY(conv->type(v) == Converter<V>::STRING);
     QVERIFY(strcmp(conv->string(v), "Hello World") == 0);
 
+    /* Convert from/to Bytes */
+    static const char BUF[] = { 'a', 'b', '\0', 'c', 'd' };
+    v = conv->fromBytes(QByteArray(BUF, sizeof(BUF)));
+    QVERIFY(conv->type(v) == Converter<V>::BYTES);
+    QByteArray res = conv->bytes(v);
+    QVERIFY(res.size() == sizeof(BUF));
+    QVERIFY(memcmp(BUF, res.constData(), res.size()) == 0);
+
     /* Convert from/to List */
     ListBuilder<V> *builder = conv->newList();
     v = conv->fromInteger(444);


### PR DESCRIPTION
Currently, it's impossible to pass `QByteArray` to python code or return `bytes` from python code without conversion to unicode `QString`. It's undesirable behavior for embedded Python3 because in case we want to return unicode string from python code it will be `string` and in other cases, we need to be able to use `bytes` to return some binary strings to C++ code.