### PR TITLE
Use python.h wrapping to allow embedding as-is in any Qt-based project

### DIFF
--- a/src/ensure_gil_state.h
+++ b/src/ensure_gil_state.h
@@ -17,7 +17,7 @@
  * PERFORMANCE OF THIS SOFTWARE.
  **/
 
-#include "Python.h"
+#include "python_wrap.h"
 
 class EnsureGILState {
     public:

--- a/src/pyglarea.h
+++ b/src/pyglarea.h
@@ -19,7 +19,7 @@
 #ifndef PYOTHERSIDE_PYGLAREA_H
 #define PYOTHERSIDE_PYGLAREA_H
 
-#include "Python.h"
+#include "python_wrap.h"
 
 #include <QString>
 #include <QVariant>

--- a/src/pyglrenderer.h
+++ b/src/pyglrenderer.h
@@ -19,7 +19,7 @@
 #ifndef PYOTHERSIDE_PYGLRENDERER_H
 #define PYOTHERSIDE_PYGLRENDERER_H
 
-#include "Python.h"
+#include "python_wrap.h"
 
 #include <QVariant>
 #include <QString>

--- a/src/pyobject_converter.h
+++ b/src/pyobject_converter.h
@@ -22,7 +22,7 @@
 #include "converter.h"
 #include "pyqobject.h"
 
-#include "Python.h"
+#include "python_wrap.h"
 #include "datetime.h"
 #include <QDebug>
 

--- a/src/pyobject_ref.h
+++ b/src/pyobject_ref.h
@@ -20,7 +20,7 @@
 #ifndef PYOTHERSIDE_PYOBJECT_REF_H
 #define PYOTHERSIDE_PYOBJECT_REF_H
 
-#include "Python.h"
+#include "python_wrap.h"
 
 #include <QMetaType>
 

--- a/src/pyqobject.h
+++ b/src/pyqobject.h
@@ -19,7 +19,7 @@
 #ifndef PYOTHERSIDE_PYQOBJECT_H
 #define PYOTHERSIDE_PYQOBJECT_H
 
-#include "Python.h"
+#include "python_wrap.h"
 
 #include "qobject_ref.h"
 

--- a/src/python_wrap.h
+++ b/src/python_wrap.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#pragma push_macro("slots")
+#undef slots
+#include "Python.h"
+#pragma pop_macro("slots")

--- a/src/qpython.h
+++ b/src/qpython.h
@@ -19,7 +19,7 @@
 #ifndef PYOTHERSIDE_QPYTHON_H
 #define PYOTHERSIDE_QPYTHON_H
 
-#include "Python.h"
+#include "python_wrap.h"
 
 #include <QVariant>
 #include <QObject>

--- a/src/qpython_priv.h
+++ b/src/qpython_priv.h
@@ -19,7 +19,7 @@
 #ifndef PYOTHERSIDE_QPYTHON_PRIV_H
 #define PYOTHERSIDE_QPYTHON_PRIV_H
 
-#include "Python.h"
+#include "python_wrap.h"
 
 #include "pyobject_ref.h"
 #include "pyqobject.h"


### PR DESCRIPTION
This is reincarnation of https://github.com/thp/pyotherside/pull/81

Currently, pyotherside is not friendly for embedding due to the conflict between `Python.h` and Qt keywords (`slots`, etc). This simple wrapping makes it usable as submodule as-is.