### PR TITLE
Don't call PyEval_InitThreads() on Python 3.7+

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1196,8 +1196,8 @@ flags for compiling and linking against Python on your system.
 ChangeLog
 =========
 
-Version 1.6.2
--------------
+Version UNRELEASED
+------------------
 
 * No longer call PyEval_InitThreads() at Python startup. It's no longer needed
   since Python 3.7.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -499,7 +499,7 @@ The image provider must return a tuple ``(data, size, format)``:
     The pixel format of ``data`` (see `constants`_),
     ``pyotherside.format_data`` if ``data`` contains an
     encoded (PNG/JPEG) image instead of raw pixel data
-    or ``pyotherside.format_svg_data`` if ``data`` contains 
+    or ``pyotherside.format_svg_data`` if ``data`` contains
     SVG image XML data.
 
 In order to register the image provider with PyOtherSide for use
@@ -1195,6 +1195,12 @@ flags for compiling and linking against Python on your system.
 
 ChangeLog
 =========
+
+Version 1.6.2
+-------------
+
+* No longer call PyEval_InitThreads() at Python startup. It's no longer needed
+  since Python 3.7.
 
 Version 1.6.1 (2024-05-18)
 --------------------------

--- a/src/qpython_priv.cpp
+++ b/src/qpython_priv.cpp
@@ -532,7 +532,6 @@ QPythonPriv::QPythonPriv()
     PyImport_AppendInittab("pyotherside", PyOtherSide_init);
 
     Py_InitializeEx(0);
-    PyEval_InitThreads();
 
     // Initialize sys.argv (https://github.com/thp/pyotherside/issues/77)
     int argc = 1;


### PR DESCRIPTION
Since Python 3.7, the function does nothing. Moreover, it's deprecated since Python 3.9:
https://docs.python.org/3.12/c-api/init.html#c.PyEval_InitThreads