### PR TITLE
Fixes PyOtherSideQtRCImporter for submodule imports

### DIFF
--- a/src/qrc_importer.py
+++ b/src/qrc_importer.py
@@ -48,9 +48,10 @@ class PyOtherSideQtRCLoader(abc.SourceLoader):
 
 class PyOtherSideQtRCImporter(abc.MetaPathFinder):
     def find_spec(self, fullname, path, target=None):
-        fname = get_filename(fullname)
-        if fname:
-            return spec_from_loader(fullname, PyOtherSideQtRCLoader(fname))
+        if path is None or all(x.startswith('qrc:') for x in path):
+            fname = get_filename(fullname)
+            if fname:
+                return spec_from_loader(fullname, PyOtherSideQtRCLoader(fname))
         return None
 
 

--- a/src/qrc_importer.py
+++ b/src/qrc_importer.py
@@ -31,7 +31,7 @@ def get_filename(fullname):
 
         for candidate in ("{}/{}.py", "{}/{}/__init__.py"):
             filename = candidate.format(import_path, basename)
-            if pyotherside.qrc_is_file(filename[len("qrc:") :]):
+            if pyotherside.qrc_is_file(filename[len("qrc:"):]):
                 return filename
 
 
@@ -40,7 +40,7 @@ class PyOtherSideQtRCLoader(abc.SourceLoader):
         self.filepath = filepath
 
     def get_data(self, path):
-        return pyotherside.qrc_get_file_contents(self.filepath[len("qrc:") :])
+        return pyotherside.qrc_get_file_contents(self.filepath[len("qrc:"):])
 
     def get_filename(self, fullname):
         return get_filename(fullname)
@@ -48,10 +48,9 @@ class PyOtherSideQtRCLoader(abc.SourceLoader):
 
 class PyOtherSideQtRCImporter(abc.MetaPathFinder):
     def find_spec(self, fullname, path, target=None):
-        if path is None:
-            fname = get_filename(fullname)
-            if fname:
-                return spec_from_loader(fullname, PyOtherSideQtRCLoader(fname))
+        fname = get_filename(fullname)
+        if fname:
+            return spec_from_loader(fullname, PyOtherSideQtRCLoader(fname))
         return None
 
 


### PR DESCRIPTION
It looks like the importer fix for python 3.12 in #131 does not cover imports of submodules. In `moment` we use `importNames()` like [this](https://gitlab.com/mx-moment/moment/-/blob/main/src/gui/PythonBridge/PythonRootBridge.qml?ref_type=heads#L24):

```
addImportPath("qrc:/src")
importNames("backend.qml_bridge", ["BRIDGE"], () => { [...] });
```

This stopped working with the upgrade to python 3.12, #131 did not fix it. When used for a submodule, the [path variable](https://github.com/thp/pyotherside/blob/master/src/qrc_importer.py#L51) is set to `the value of __path__ from the parent package` according to the [reference](https://docs.python.org/3/library/importlib.html#importlib.abc.MetaPathFinder.find_spec). By removing this `path is None` condition, it works again. Not sure though, if this MR will break other usecases though.

@apollo13: could you please test this against your setup?